### PR TITLE
Fix links to 0atman.com and namtao.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ and direct and produce a contemporary urban fantasy podcast called [Modem Promet
 
 
 ### 📌 Where to find me 
-- Blog - [0atman.com](http://0atman.com)
+- Blog - [0atman.com](https://www.0atman.com)
 - Mastodon <a rel="me" href="https://namtao.com/@tris">@tris@namtao.com</a> (used to be <a rel="me" href="https://mastodon.social/@0atman">@0atman@mastodon.social</a>)
-- My Music - [namtao.com](http://namtao.com)
+- My Music - [namtao.com](https://www.namtao.com)
 - Fast technical videos [No Boilerplate](https://www.youtube.com/c/NoBoilerplate)
 
 


### PR DESCRIPTION
When using HTTPS-ONLY mode in my browser, `http://0atman.com` is redirected to `https://0atman.com` instead of requesting the page with a location redirect to `http://www.0atman.com`.

Unfortunately `0atman.com` doesn't have a valid HTTPS certificate so this leaves the user at an invalid certificate screen.

I have fixed the domains to specify https and the full canonical URL for the websites.
